### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM jwilder/nginx-proxy:alpine
+FROM jwilder/nginx-proxy:v0.9.0
 COPY ./certs /etc/nginx/certs
 RUN { \
   echo 'server_tokens off;'; \


### PR DESCRIPTION
`jwilder/nginx-proxy` changed recently. This pull request ensures you're using the latest version of the image and changes `jwilder/nginx-proxy` to the latest tag: `v0.9.0`

New base image: `jwilder/nginx-proxy:v0.9.0`